### PR TITLE
Improve landing UX

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -32,14 +32,15 @@
   </script>
 </head>
 <body>
-  <header class="hero">
+  <header class="hero container">
     <img src="robot-placeholder.png" alt="Robot" class="hero-img">
     <h1 class="hero-title">Мастер-класс «Промтинжиниринг»</h1>
     <p class="hero-date" id="event-date"></p>
     <p class="hero-slogan">Практика применения ИИ в проф. деятельности</p>
+    <a href="#reg-form" class="primary-btn">Записаться</a>
   </header>
 
-  <section class="benefits">
+  <section class="benefits container">
     <h2>Что получите за 1,5&nbsp;ч</h2>
     <ul>
       <li>Навыки точного формулирования запросов к ИИ</li>
@@ -49,38 +50,33 @@
     </ul>
   </section>
 
-  <section class="form-section">
+  <section class="form-section container">
     <h2>Регистрация</h2>
     <form id="reg-form">
-      <label>
-        Имя
-        <input type="text" name="name" required>
-      </label>
-      <label>
-        E-mail
-        <input type="email" name="email" required>
-      </label>
-      <label>
-        Телефон
-        <input type="tel" name="phone">
-      </label>
+      <label for="name">Имя</label>
+      <input id="name" type="text" name="name" required aria-required="true">
+      <label for="email">E-mail</label>
+      <input id="email" type="email" name="email" required aria-required="true">
+      <label for="phone">Телефон</label>
+      <input id="phone" type="tel" name="phone" pattern="\+?[0-9\s\-]{10,}" placeholder="+7 123 456-78-90">
       <fieldset>
         <legend>Формат участия</legend>
-        <label>
-          <input type="radio" name="mode" value="offline" required>
+        <label for="mode-offline">
+          <input id="mode-offline" type="radio" name="mode" value="offline" required aria-checked="false">
           Очно — 5 000 ₽ (<span id="offline-left">11</span> мест)
         </label>
-        <label>
-          <input type="radio" name="mode" value="online">
+        <label for="mode-online">
+          <input id="mode-online" type="radio" name="mode" value="online" aria-checked="false">
           Онлайн (Zoom) — 2 500 ₽ (<span id="online-left">8</span> мест)
         </label>
       </fieldset>
       <button type="submit" id="submit-btn">Записаться</button>
       <div class="spinner" id="spinner" hidden></div>
+      <div id="message" hidden role="alert"></div>
     </form>
   </section>
 
-  <section class="bonus">
+  <section class="bonus container">
     <h2>Бонусы</h2>
     <ul>
       <li>Доступ в закрытый Telegram-чат</li>
@@ -88,7 +84,8 @@
     </ul>
   </section>
 
-  <footer>
+  <footer class="container">
+    <button id="theme-toggle" type="button">Тёмная тема</button>
     <a class="contact-btn" href="tg://resolve?domain=Step_3D_Mngr">Написать менеджеру Никите</a>
     <p class="hashtags">#МЕЧТАЙ #УЧИСЬ #ТВОРИ #ВДОХНОВЛЯЙ</p>
     <p>© 2025 ФГБОУ ВО РГСУ</p>

--- a/public/script.js
+++ b/public/script.js
@@ -6,6 +6,8 @@ const onlineLeftEl = document.getElementById('online-left');
 const submitBtn = document.getElementById('submit-btn');
 const form = document.getElementById('reg-form');
 const spinner = document.getElementById('spinner');
+const messageEl = document.getElementById('message');
+const themeToggle = document.getElementById('theme-toggle');
 
 function formatDate() {
   const date = new Date('2025-06-11T19:00:00+03:00');
@@ -29,6 +31,15 @@ async function updateSeats() {
   }
 }
 
+function showMessage(text, isError = false) {
+  messageEl.textContent = text;
+  messageEl.className = isError ? 'error' : 'success';
+  messageEl.hidden = false;
+  setTimeout(() => {
+    messageEl.hidden = true;
+  }, 4000);
+}
+
 form.addEventListener('submit', async (e) => {
   e.preventDefault();
   submitBtn.disabled = true;
@@ -43,14 +54,14 @@ form.addEventListener('submit', async (e) => {
     });
     const res = await resp.json();
     if (res.status === 'ok') {
-      alert('Успешно! Инструкция отправлена на почту');
+      showMessage('Успешно! Инструкция отправлена на почту');
       form.reset();
       updateSeats();
     } else {
-      alert('Ошибка: ' + res.message);
+      showMessage('Ошибка: ' + res.message, true);
     }
   } catch (err) {
-    alert('Ошибка отправки');
+    showMessage('Ошибка отправки', true);
   } finally {
     submitBtn.disabled = false;
     spinner.hidden = true;
@@ -59,3 +70,9 @@ form.addEventListener('submit', async (e) => {
 
 formatDate();
 updateSeats();
+
+themeToggle.addEventListener('click', () => {
+  const isDark = document.documentElement.dataset.theme === 'dark';
+  document.documentElement.dataset.theme = isDark ? 'light' : 'dark';
+  themeToggle.textContent = isDark ? 'Тёмная тема' : 'Светлая тема';
+});

--- a/public/style.css
+++ b/public/style.css
@@ -4,6 +4,14 @@
   font-family: Inter, -apple-system, sans-serif;
 }
 
+html { scroll-behavior: smooth; }
+
+.container {
+  max-width: 640px;
+  margin: 0 auto;
+  padding: 0 1rem;
+}
+
 body {
   margin: 0;
   padding: 0;
@@ -21,6 +29,11 @@ header.hero {
   width: 120px;
   height: 120px;
   object-fit: cover;
+  transition: transform 0.3s ease;
+}
+
+.hero-img:hover {
+  transform: rotate(5deg) scale(1.05);
 }
 
 .hero-title {
@@ -95,6 +108,15 @@ button[disabled] {
   margin: 0.5rem auto;
 }
 
+#message {
+  text-align: center;
+  margin-top: 0.5rem;
+  font-weight: 700;
+}
+
+#message.success { color: var(--accent); }
+#message.error { color: #cc0000; }
+
 @keyframes spin {
   0% { transform: rotate(0deg); }
   100% { transform: rotate(360deg); }
@@ -113,8 +135,40 @@ footer {
   color: var(--accent);
 }
 
+.primary-btn {
+  display: inline-block;
+  margin-top: 1rem;
+  background: var(--accent);
+  color: #fff;
+  padding: 0.5rem 1rem;
+  text-decoration: none;
+  border-radius: 4px;
+}
+
+#theme-toggle {
+  background: none;
+  border: 1px solid var(--accent);
+  color: var(--accent);
+  padding: 0.25rem 0.5rem;
+  margin-bottom: 0.5rem;
+  cursor: pointer;
+}
+
 .hashtags {
   font-weight: 700;
+}
+
+[data-theme="dark"] {
+  background: #222;
+  color: #eee;
+}
+
+[data-theme="dark"] footer {
+  background: #333;
+}
+
+[data-theme="dark"] .primary-btn {
+  background: #4c8cff;
 }
 
 @media (min-width: 600px) {


### PR DESCRIPTION
## Summary
- add container layout and registration link
- enhance form markup with placeholders and id labels
- provide theme toggle, dark theme styles and message box
- style hero image hover effects and main buttons
- switch form alerts to inline messages

## Testing
- `node -v`
- `node -e "console.log('ok')"`


------
https://chatgpt.com/codex/tasks/task_e_68470d4380848333a8893fe769f9249c