### PR TITLE
Improve dark mode and UX

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -3,11 +3,13 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="color-scheme" content="light dark">
     <title>Промтинжиниринг — мастер‑класс StepAI 2025</title>
     <link rel="stylesheet" href="style.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet">
+    <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" onload="this.rel='stylesheet'">
+    <noscript><link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet"></noscript>
     <link rel="icon" href="favicon.ico">
     <meta name="description" content="Практика применения ИИ в профессиональной деятельности">
     <meta property="og:title" content="Мастер-класс «Промтинжиниринг»">
@@ -42,7 +44,7 @@
 </head>
 <body>
     <header class="hero container">
-        <div class="hero-animation" aria-label="Robot animation"></div>
+        <div class="hero-animation" aria-hidden="true"></div>
         <h1 class="hero-title">Мастер-класс «Промтинжиниринг»</h1>
         <time id="event-date" class="hero-date" datetime="2025-06-11T19:00:00+03:00"></time>
         <p class="hero-slogan">Практика применения ИИ в проф. деятельности</p>
@@ -50,6 +52,7 @@
         <a href="#reg-form" class="primary-btn">Записаться</a>
         <button id="theme-toggle" class="theme-toggle" aria-label="Переключить тему">🌙</button>
     </header>
+    <main>
 
     <section class="benefits container">
         <h2>Что получите за 1,5&nbsp;ч</h2>
@@ -101,8 +104,9 @@
         </ul>
     </section>
 
+    </main>
     <footer class="container">
-                <a class="contact-btn" href="tg://resolve?domain=Step_3D_Mngr" target="_blank" rel="noopener"><img loading="lazy" src="telegram.svg" alt="" class="telegram-logo">Написать менеджеру Никите</a>
+                <a class="contact-btn" href="tg://resolve?domain=Step_3D_Mngr" target="_blank" rel="noopener noreferrer"><img loading="lazy" src="telegram.svg" alt="" class="telegram-logo">Написать менеджеру Никите</a>
         <p class="hashtags">#МЕЧТАЙ #УЧИСЬ #ТВОРИ #ВДОХНОВЛЯЙ</p>
         <p>© 2025 ФГБОУ ВО РГСУ</p>
         <p class="legal">Нажимая кнопку «Записаться», вы соглашаетесь на <a href="privacy.html">обработку персональных данных</a> и принимаете <a href="offer.html">условия публичной оферты</a> от © STEP_3D | Lab.</p>

--- a/public/offer.html
+++ b/public/offer.html
@@ -2,6 +2,8 @@
 <html lang="ru">
 <head>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="color-scheme" content="light dark">
     <title>Публичная оферта</title>
     <link rel="stylesheet" href="style.css">
 </head>

--- a/public/privacy.html
+++ b/public/privacy.html
@@ -2,6 +2,8 @@
 <html lang="ru">
 <head>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="color-scheme" content="light dark">
     <title>Согласие на обработку персональных данных</title>
     <link rel="stylesheet" href="style.css">
 </head>

--- a/public/script.js
+++ b/public/script.js
@@ -9,6 +9,16 @@ const spinner = document.getElementById('spinner');
 const messageEl = document.getElementById('message');
 const themeToggle = document.getElementById("theme-toggle");
 const backToTop = document.querySelector(".back-to-top");
+
+function applyTheme(isDark) {
+    document.body.classList.toggle('dark', isDark);
+    themeToggle.textContent = isDark ? '☀️' : '🌙';
+    themeToggle.setAttribute('aria-label', isDark ? 'Светлая тема' : 'Темная тема');
+}
+
+const savedTheme = localStorage.getItem('theme');
+const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+applyTheme(savedTheme ? savedTheme === 'dark' : prefersDark);
 function formatDate() {
     const date = new Date('2025-06-11T19:00:00+03:00');
     const options = { weekday: 'long', day: 'numeric', month: 'long' };
@@ -70,7 +80,11 @@ form.addEventListener('submit', async (e) => {
 
 formatDate();
 updateSeats();
-themeToggle.addEventListener("click", () => document.body.classList.toggle("dark"));
+themeToggle.addEventListener('click', () => {
+    const isDark = !document.body.classList.contains('dark');
+    applyTheme(isDark);
+    localStorage.setItem('theme', isDark ? 'dark' : 'light');
+});
 window.addEventListener("scroll", () => {
     backToTop.classList.toggle("visible", window.scrollY > 100);
 });

--- a/public/style.css
+++ b/public/style.css
@@ -4,10 +4,18 @@
     --text-light: #eee;
     --bg-light: #fff;
     --bg-dark: #222;
+    --bg-footer-light: #f9f9f9;
+    --bg-footer-dark: #1b1b1b;
+    --link-light: #0066FF;
+    --link-dark: #66aaff;
+    --card-light: #fff;
+    --card-dark: #333;
+    --border-radius: 8px;
     font-family: "Inter", -apple-system, sans-serif;
 }
 
 html { scroll-behavior: smooth; }
+img { max-width: 100%; height: auto; }
 
 .container {
     max-width: 640px;
@@ -21,6 +29,7 @@ body {
     color: var(--text-dark);
     background: var(--bg-light);
     line-height: 1.4;
+    font-size: 16px;
     transition: background 0.3s, color 0.3s;
 }
 body.dark {
@@ -31,6 +40,12 @@ body.dark {
 header.hero {
     text-align: center;
     padding: 2rem 1rem;
+    background: var(--card-light);
+    border-radius: var(--border-radius);
+    margin-bottom: 1rem;
+}
+body.dark header.hero {
+    background: var(--card-dark);
 }
 
 .hero-animation {
@@ -39,6 +54,9 @@ header.hero {
     animation: spin 4s linear infinite;
     width: 120px;
     height: 120px;
+body.dark .hero-animation {
+    background: conic-gradient(var(--accent), #000, var(--accent));
+}
         
 }
 
@@ -64,6 +82,15 @@ header.hero {
 .bonus,
 .speaker {
     padding: 1rem;
+    background: var(--card-light);
+    border-radius: var(--border-radius);
+    margin-bottom: 1rem;
+}
+body.dark .benefits,
+body.dark .form-section,
+body.dark .bonus,
+body.dark .speaker {
+    background: var(--card-dark);
 }
 
 .benefits ul,
@@ -142,13 +169,28 @@ footer {
     text-align: center;
     padding: 1rem;
     font-size: 0.875rem;
-    background: #f9f9f9;
+    background: var(--bg-footer-light);
+}
+body.dark footer {
+    background: var(--bg-footer-dark);
+}
+.contact-btn,
+a {
+    color: var(--link-light);
+    transition: color 0.3s;
+}
+body.dark .contact-btn,
+body.dark a {
+    color: var(--link-dark);
+}
+::selection {
+    background: var(--accent);
+    color: #fff;
 }
 
 .contact-btn {
     display: inline-block;
     margin-bottom: 0.5rem;
-    color: var(--accent);
 }
 .telegram-logo { width: 1em; vertical-align: middle; margin-right: 0.25rem; }
 
@@ -159,7 +201,11 @@ footer {
     color: #fff;
     padding: 0.5rem 1rem;
     text-decoration: none;
-    border-radius: 4px;
+    border-radius: var(--border-radius);
+    transition: background 0.3s;
+}
+.primary-btn:hover {
+    background: #0050cc;
 }
 .calendar-btn {
     display: inline-block;
@@ -169,8 +215,19 @@ footer {
     color: var(--accent);
     padding: 0.5rem 1rem;
     text-decoration: none;
-    border-radius: 4px;
+    border-radius: var(--border-radius);
     border: 1px solid var(--accent);
+    transition: background 0.3s, color 0.3s;
+}
+body.dark .calendar-btn {
+    background: #333;
+    color: var(--link-dark);
+}
+.calendar-btn:hover {
+    background: #e6e6e6;
+}
+body.dark .calendar-btn:hover {
+    background: #444;
 }
 .calendar-icon {
     width: 1em;
@@ -180,7 +237,7 @@ footer {
 }
 
 
-a:focus, button:focus, input:focus {
+a:focus-visible, button:focus-visible, input:focus-visible {
     outline: 2px solid var(--accent);
     outline-offset: 2px;
 }
@@ -190,6 +247,7 @@ a:focus, button:focus, input:focus {
     cursor: pointer;
     font-size: 1.2rem;
     margin-left: 0.5rem;
+    transition: transform 0.3s;
 }
 .back-to-top {
     position: fixed;
@@ -198,12 +256,17 @@ a:focus, button:focus, input:focus {
     background: var(--accent);
     color: #fff;
     padding: 0.5rem;
-    border-radius: 4px;
+    border-radius: var(--border-radius);
     text-decoration: none;
     display: none;
+    transition: opacity 0.3s;
 }
 .back-to-top.visible {
     display: block;
+    opacity: 0.8;
+}
+.back-to-top:hover {
+    opacity: 1;
 }
 @media (prefers-reduced-motion: reduce) {
     .hero-animation, .spinner {


### PR DESCRIPTION
## Summary
- add color-scheme metadata and preload fonts
- add responsive main container and style tweaks
- enhance dark theme styles and link colors
- persist theme setting with localStorage
- upgrade mobile meta tags

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68471e34090883339d68ed4153eba5d8